### PR TITLE
Prevent verification when no partial download is in progress.

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -107,7 +107,8 @@ func start(verify = false, dozip=true):
 	emit_signal("started")
 	var dir = Directory.new()
 	var error
-	if tvn.check_partial_download(path) != tvn.FAIL:
+
+	if tvn.check_partial_download(path) > 0:
 		verify = true
 #	if installed_revision == -1 and verify == false and dozip == true:  # the zip thing
 #		pass


### PR DESCRIPTION
Initially added in 5a41ff8fb437efd7639ed962153f0ea6e79c8d60

`check_partial_download` no longer returns `tvn.FAIL` but -1.