### PR TITLE
Adjust button hover colour to fix #32

### DIFF
--- a/ui_theme.tres
+++ b/ui_theme.tres
@@ -10,7 +10,7 @@ bg_color = Color( 0.184314, 0.101961, 0.258824, 1 )
 [sub_resource type="StyleBoxEmpty" id=21]
 
 [sub_resource type="StyleBoxFlat" id=22]
-bg_color = Color( 0.239216, 0.160784, 0.317647, 1 )
+bg_color = Color( 0.262745, 0.176471, 0.34902, 1 )
 border_color = Color( 0.933333, 0.882353, 0.811765, 1 )
 
 [sub_resource type="StyleBoxFlat" id=11]


### PR DESCRIPTION
Colours are now #432d59, previously #3d2951. Makes it so that all buttons have a hover effect, as the old colour was just the primary dark purple shade used normally.

This is still not a satisfactory fix, in my opinion. The effect is too subtle to notice at times, but it's reusing colours a part of the colour palette. We could use #584169 instead as it's brighter and better for this use case. However, the install directory button uses that same colour. I can have another go at it later.

Current behaviour:
![Screenshot_20230130_151520](https://user-images.githubusercontent.com/18003771/215618093-3fdb9be3-f71a-4168-9c0e-6327f5281da5.png)
![Screenshot_20230130_151341](https://user-images.githubusercontent.com/18003771/215617845-f81c83e6-7db3-4b58-a7b7-70667b44f4f9.png)

Pull request changes:
![Screenshot_20230130_151410](https://user-images.githubusercontent.com/18003771/215617945-0ed88f17-dc41-4263-869c-8ba81e1de065.png)
![Screenshot_20230130_151439](https://user-images.githubusercontent.com/18003771/215618006-bac8e27b-008f-4cc0-b821-77c094fa8a76.png)
